### PR TITLE
Fix[RS-737] -  fix details for referral comments

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
     can :read, Referral, referred_by: user.id, active: true
     can :recruiters, User, active: true
     can [:create, :update], Referral, referrer: user
-    can [:index, :create], ReferralComment
+    can [:index, :create], ReferralComment, author: user
     can :read, Role, id: user.role_id
 
     # User abilities


### PR DESCRIPTION
Fixes:
- avoid the 404 response when no comments
- fix the error on the referral_comment `create`
- add the feature to create the referral_comment when the status is updated on the referral update endpoint
